### PR TITLE
feat: increase_amount_and_duration

### DIFF
--- a/sources/scripts.move
+++ b/sources/scripts.move
@@ -18,12 +18,16 @@ module vetoken::scripts {
 
     public entry fun unlock<CoinType>(account: &signer) {
         let coin = vetoken::unlock<CoinType>(account);
-        coin::deposit<CoinType>(signer::address_of(account), coin);
+        coin::deposit(signer::address_of(account), coin);
     }
 
     public entry fun increase_lock_amount<CoinType>(account: &signer, amount: u64) {
+        increase_lock_amount_and_duration<CoinType>(account, amount, 0);
+    }
+
+    public entry fun increase_lock_amount_and_duration<CoinType>(account: &signer, amount: u64, increment_epochs: u64) {
         let coin = coin::withdraw<CoinType>(account, amount);
-        vetoken::increase_lock_amount<CoinType>(account, coin);
+        vetoken::increase_lock_amount_and_duration(account, coin, increment_epochs);
     }
 
     public entry fun claim<LockCoin, DividendCoin>(account: &signer) {

--- a/sources/vetoken.move
+++ b/sources/vetoken.move
@@ -202,7 +202,7 @@ module vetoken::vetoken {
         let locked_amount = (coin::value(&vetoken_store.vetoken.locked) as u128);
 
         let old_unlockable_epoch = vetoken_store.vetoken.unlockable_epoch;
-        let new_unlockable_epoch = vetoken_store.vetoken.unlockable_epoch + increment_epochs;
+        let new_unlockable_epoch = old_unlockable_epoch + increment_epochs;
         let vetoken_info = borrow_global_mut<VeTokenInfo<CoinType>>(account_address<CoinType>());
         assert!(new_unlockable_epoch - now_epoch <= vetoken_info.max_locked_epochs, ERR_VETOKEN_INVALID_LOCK_DURATION);
 


### PR DESCRIPTION
Separately increasing lock duration and amount requires double the amount gas to loop through the applicable epochs.

Provide `increase_amount_and_duration` resulting in only 1 loop for this operation