### PR TITLE
fix: correct next_claimable

### DIFF
--- a/sources/dividend_distributor.move
+++ b/sources/dividend_distributor.move
@@ -50,7 +50,7 @@ module vetoken::dividend_distributor {
 
     struct ClaimDividendEvent<phantom LockCoin, phantom DividendCoin> has drop, store {
         account_addr: address,
-        /// The event is emitted when the user has claimed dividend up to (excluding) this epoch
+        /// The event is emitted when the user has claimed dividend up to (including) this epoch
         epoch_until: u64,
         claimed_amount: u64,
     }
@@ -110,18 +110,20 @@ module vetoken::dividend_distributor {
         assert!(initialized<LockCoin, DividendCoin>(), ERR_DIVIDEND_DISTRIBUTOR_UNINITIALIZED);
 
         let account_addr = signer::address_of(account);
-        let claimable = claimable<LockCoin, DividendCoin>(account_addr);
+        let (claimable, next_claimable_index) = claimable_internal<LockCoin, DividendCoin>(account_addr);
+
+        // there's no dividend distributed yet
+        if (next_claimable_index == 0) {
+            return coin::zero()
+        };
 
         let distributor = borrow_global_mut<DividendDistributor<LockCoin, DividendCoin>>(account_address<LockCoin>());
-        smart_table::upsert(&mut distributor.next_claimable, account_addr, smart_vector::length(&distributor.epoch_dividend
-        ));
-
+        smart_table::upsert(&mut distributor.next_claimable, account_addr, next_claimable_index);
         event::emit_event<ClaimDividendEvent<LockCoin, DividendCoin>>(
             &mut distributor.claim_dividend_events,
             ClaimDividendEvent {
                 account_addr,
-                epoch_until: smart_vector::borrow(&distributor.epoch_dividend, smart_vector::length(&distributor.epoch_dividend
-                ) - 1).epoch,
+                epoch_until: smart_vector::borrow(&distributor.epoch_dividend, next_claimable_index - 1).epoch,
                 claimed_amount: claimable
             }
         );
@@ -136,9 +138,21 @@ module vetoken::dividend_distributor {
 
     #[view]
     /// Claimable dividend as a VeToken<LockCoin> holder.
+    public fun claimable<LockCoin, DividendCoin>(account_addr: address): u64 acquires DividendDistributor {
+        let (total_claimable, _) = claimable_internal<LockCoin, DividendCoin>(account_addr);
+        total_claimable
+    }
+
+    fun account_address<Type>(): address {
+        let type_info = type_info::type_of<Type>();
+        type_info::account_address(&type_info)
+    }
+
+    /// Returns (claimable amount, next claimable index)
+    /// Claimable dividend as a VeToken<LockCoin> holder.
     /// Only past epochs are claimable, this is b/c holder's weight in the current epoch subjects to changes
     /// through increase_lock_duration or increase_lock_amount.
-    public fun claimable<LockCoin, DividendCoin>(account_addr: address): u64 acquires DividendDistributor {
+    fun claimable_internal<LockCoin, DividendCoin>(account_addr: address): (u64, u64) acquires DividendDistributor {
         let total_claimable = 0;
         let distributor = borrow_global<DividendDistributor<LockCoin, DividendCoin>>(account_address<LockCoin>());
         let now_epoch = now_epoch<LockCoin>();
@@ -163,12 +177,8 @@ module vetoken::dividend_distributor {
 
             i = i + 1;
         };
-        total_claimable
-    }
 
-    fun account_address<Type>(): address {
-        let type_info = type_info::type_of<Type>();
-        type_info::account_address(&type_info)
+        (total_claimable, i)
     }
 
     #[test_only]
@@ -188,7 +198,7 @@ module vetoken::dividend_distributor {
     }
 
     #[test(aptos_framework = @aptos_framework, vetoken = @vetoken)]
-    fun past_epochs_claimable(aptos_framework: &signer, vetoken: &signer) acquires DividendDistributor {
+    fun claim_past_epoch_dividend_ok(aptos_framework: &signer, vetoken: &signer) acquires DividendDistributor {
         initialize_for_test(aptos_framework, vetoken, 1, 52);
 
         let user = &account::create_account_for_test(@0xA);
@@ -203,6 +213,33 @@ module vetoken::dividend_distributor {
         // can claim dividend distributed in the past epochs
         timestamp::fast_forward_seconds(vetoken::seconds_in_epoch<FakeLockCoin>());
         assert!(claimable<FakeLockCoin, FakeDividendCoin>(@0xA) == 100000000, 0);
+    }
+
+    #[test(aptos_framework = @aptos_framework, vetoken = @vetoken)]
+    fun claim_current_epoch_dividend_ok(aptos_framework: &signer, vetoken: &signer) acquires DividendDistributor {
+        initialize_for_test(aptos_framework, vetoken, 1, 52);
+
+        let user = &account::create_account_for_test(@0xA);
+        vetoken::register<FakeLockCoin>(user);
+        vetoken::lock(user, coin_test::mint_coin<FakeLockCoin>(vetoken, 10000), 52);
+
+        distribute<FakeLockCoin, FakeDividendCoin>(coin_test::mint_coin<FakeDividendCoin>(vetoken, 100000000));
+        assert!(claimable<FakeLockCoin, FakeDividendCoin>(@0xA) == 0, 0);
+        let dividend = claim<FakeLockCoin, FakeDividendCoin>(user);
+        assert!(coin::value(&dividend) == 0, 0);
+        coin_test::burn_coin(vetoken, dividend);
+
+        timestamp::fast_forward_seconds(vetoken::seconds_in_epoch<FakeLockCoin>());
+        distribute<FakeLockCoin, FakeDividendCoin>(coin_test::mint_coin<FakeDividendCoin>(vetoken, 200000000));
+        assert!(claimable<FakeLockCoin, FakeDividendCoin>(@0xA) == 100000000, 0);
+        let dividend = claim<FakeLockCoin, FakeDividendCoin>(user);
+        assert!(coin::value(&dividend) == 100000000, 0);
+        coin_test::burn_coin(vetoken, dividend);
+
+        timestamp::fast_forward_seconds(vetoken::seconds_in_epoch<FakeLockCoin>());
+        let dividend = claim<FakeLockCoin, FakeDividendCoin>(user);
+        assert!(coin::value(&dividend) == 200000000, 0);
+        coin_test::burn_coin(vetoken, dividend);
     }
 
     #[test(aptos_framework = @aptos_framework, vetoken = @vetoken)]


### PR DESCRIPTION
previously, let's say the current epoch is 3, and epoch_dividend is [epoch: 1, dividend: 100] -> [epoch: 2, dividend: 200] -> [epoch: 3, dividend: 50], after calling `claim`, next_claimable is updated to be 3, while [epoch: 3, dividend: 50] hasn't been claimed and will be skipped on next claim, which is a bug.

after the fix, next_claimable will be updated to be 2 in this case.