### PR TITLE
fix: handle zero input amount in lock_composed

### DIFF
--- a/sources/composable_vetoken.move
+++ b/sources/composable_vetoken.move
@@ -1,7 +1,6 @@
 module vetoken::composable_vetoken {
     use std::signer;
 
-    use aptos_framework::coin::Coin;
     use aptos_std::type_info;
 
     use vetoken::dividend_distributor;
@@ -67,14 +66,6 @@ module vetoken::composable_vetoken {
 
         composable_vetoken.weight_percent_coin_a = weight_percent_coin_a;
         composable_vetoken.weight_percent_coin_b = weight_percent_coin_b;
-    }
-
-    /// Lock two tokens for the `ComposedVeToken2` configuration.
-    public fun lock<CoinTypeA, CoinTypeB>(account: &signer, coin_a: Coin<CoinTypeA>, coin_b: Coin<CoinTypeB>, locked_epochs: u64) {
-        assert!(initialized<CoinTypeA, CoinTypeB>(), ERR_COMPOSABLE_VETOKEN2_UNINITIALIZED);
-
-        vetoken::lock(account, coin_a, locked_epochs);
-        vetoken::lock(account, coin_b, locked_epochs);
     }
 
     #[view] /// Query for the weight configuration

--- a/sources/composable_vetoken.move
+++ b/sources/composable_vetoken.move
@@ -276,34 +276,6 @@ module vetoken::composable_vetoken {
     }
 
     #[test(aptos_framework = @aptos_framework, vetoken = @vetoken)]
-    fun composable_vetoken_lock_ok(aptos_framework: &signer, vetoken: &signer) {
-        initialize_for_test(aptos_framework, vetoken, 1, 4);
-        initialize<FakeCoinA, FakeCoinB>(vetoken, 100, 50, true);
-
-        let epoch = vetoken::now_epoch<FakeCoinA>();
-
-        let account = &account::create_account_for_test(@0xA);
-        lock(account, coin_test::mint_coin<FakeCoinA>(vetoken, 1000), coin_test::mint_coin<FakeCoinB>(vetoken, 1000), 1);
-        assert!(vetoken::balance<FakeCoinA>(signer::address_of(account)) == 250, 0);
-        assert!(vetoken::balance<FakeCoinB>(signer::address_of(account)) == 250, 0);
-        assert!(vetoken::unlockable_epoch<FakeCoinA>(signer::address_of(account)) == epoch + 1, 0);
-        assert!(vetoken::unlockable_epoch<FakeCoinB>(signer::address_of(account)) == epoch + 1, 0);
-    }
-
-    #[test(aptos_framework = @aptos_framework, vetoken = @vetoken)]
-    #[expected_failure(abort_code = vetoken::vetoken::ERR_VETOKEN_LOCKED)]
-    fun composable_vetoken_locked_err(aptos_framework: &signer, vetoken: &signer) {
-        initialize_for_test(aptos_framework, vetoken, 1, 4);
-        initialize<FakeCoinA, FakeCoinB>(vetoken, 100, 50, true);
-
-        let account = &account::create_account_for_test(@0xA);
-        vetoken::lock(account, coin_test::mint_coin<FakeCoinA>(vetoken, 1000), 1);
-
-        // FakeCoinA is already locked
-        lock(account, coin_test::mint_coin<FakeCoinA>(vetoken, 1000), coin_test::mint_coin<FakeCoinB>(vetoken, 1000), 1);
-    }
-
-    #[test(aptos_framework = @aptos_framework, vetoken = @vetoken)]
     fun composable_vetoken_balance_ok(aptos_framework: &signer, vetoken: &signer) acquires ComposedVeToken2 {
         initialize_for_test(aptos_framework, vetoken, 1, 4);
         initialize<FakeCoinA, FakeCoinB>(vetoken, 100, 50, true);

--- a/sources/scripts.move
+++ b/sources/scripts.move
@@ -4,7 +4,6 @@ module vetoken::scripts {
     use aptos_std::type_info;
     use aptos_framework::coin;
 
-    use vetoken::composable_vetoken;
     use vetoken::dividend_distributor;
     use vetoken::vetoken;
     
@@ -40,9 +39,12 @@ module vetoken::scripts {
     }
 
     public entry fun lock_composed<LockCoinA, LockCoinB>(account: &signer, amount_a: u64, amount_b: u64, epochs: u64) {
-        let coin_a = coin::withdraw<LockCoinA>(account, amount_a);
-        let coin_b = coin::withdraw<LockCoinB>(account, amount_b);
-        composable_vetoken::lock(account, coin_a, coin_b, epochs);
+        if (amount_a > 0) {
+            vetoken::lock(account, coin::withdraw<LockCoinA>(account, amount_a), epochs);
+        };
+        if (amount_b > 0) {
+            vetoken::lock(account, coin::withdraw<LockCoinB>(account, amount_b), epochs);
+        };
     }
 
     public entry fun claim_composed<LockCoinA, LockCoinB, DividendCoin>(account: &signer) {


### PR DESCRIPTION
It's not a must to have composable_vetoken initialized before locking coin a and coin b in 1 tx. Let's remove the public function in `composable_vetoken` to reduce code size