### PR TITLE
feat: snapshot composable vetoken weights

### DIFF
--- a/sources/composable_vetoken.move
+++ b/sources/composable_vetoken.move
@@ -147,10 +147,10 @@ module vetoken::composable_vetoken {
         else if (epoch == snapshot.epoch) return (snapshot.weight_percent_coin_a, snapshot.weight_percent_coin_b);
 
         // Binary search a snapshot where the epoch is the highest behind the target epoch. The checks
-        // before this reaching this search ensures that the supplied epoch is in range of [low, hi]
+        // before reaching this search ensures that the supplied epoch is in range of [low, hi]
         //
-        // NOTE: If we reach the terminating condition, low >= hi, then that indicates the the last value
-        // set for `snapshot` (index low - 1) is desired value
+        // NOTE: If we reach the terminating condition, low >= hi, then that indicates the index
+        // (low - 1) is the right snapshot with the highest epoch below the target
         let low = 0;
         let high = num_snapshots - 1;
         while (low < high) {
@@ -164,6 +164,7 @@ module vetoken::composable_vetoken {
             else high = mid
         };
 
+        snapshot = vector::borrow(snapshots, low - 1);
         return (snapshot.weight_percent_coin_a, snapshot.weight_percent_coin_b)
     }
 

--- a/sources/composable_vetoken.move
+++ b/sources/composable_vetoken.move
@@ -130,7 +130,7 @@ module vetoken::composable_vetoken {
 
         // Check if the latest snapshot suffices
         let snapshot = vector::borrow(snapshots, num_snapshots - 1);
-        if (epoch == snapshot.epoch) return (snapshot.weight_percent_coin_a, snapshot.weight_percent_coin_b);
+        if (epoch >= snapshot.epoch) return (snapshot.weight_percent_coin_a, snapshot.weight_percent_coin_b);
 
         // Check if the first snapshot sufficies or the supplied epoch is too far in the past
         let snapshot = vector::borrow(snapshots, 0);
@@ -320,36 +320,48 @@ module vetoken::composable_vetoken {
         initialize_for_test(aptos_framework, vetoken, 1, 4);
 
         // Epoch 0 holds no weight configuration
-        timestamp::fast_forward_seconds(vetoken::seconds_in_epoch<FakeCoinA>());
+
+        // Epoch 5
+        timestamp::fast_forward_seconds(5*vetoken::seconds_in_epoch<FakeCoinA>());
         initialize<FakeCoinA, FakeCoinB>(vetoken, 100, 50, true);
+        update_weights<FakeCoinA, FakeCoinB>(vetoken, 33, 67); // changed in the same epoch
 
-        // Epoch 1
-        let (weight_a, weight_b) = past_weight_percents<FakeCoinA, FakeCoinB>(0);
-        assert!(weight_a == 0, 0);
-        assert!(weight_b == 0, 0);
-
-        let (weight_a, weight_b) = past_weight_percents<FakeCoinA, FakeCoinB>(1);
-        assert!(weight_a == 100, 0);
-        assert!(weight_b == 50, 0);
-
-        update_weights<FakeCoinA, FakeCoinB>(vetoken, 33, 67);
-        let (weight_a, weight_b) = past_weight_percents<FakeCoinA, FakeCoinB>(1);
-        assert!(weight_a == 33, 0);
-        assert!(weight_b == 67, 0);
-
-        // Epoch 2
-        timestamp::fast_forward_seconds(vetoken::seconds_in_epoch<FakeCoinA>());
+        // Epoch 10
+        timestamp::fast_forward_seconds(5*vetoken::seconds_in_epoch<FakeCoinA>());
         update_weights<FakeCoinA, FakeCoinB>(vetoken, 50, 50);
 
+        // Epoch [0,4]
         let (weight_a, weight_b) = past_weight_percents<FakeCoinA, FakeCoinB>(0);
         assert!(weight_a == 0, 0);
         assert!(weight_b == 0, 0);
 
-        let (weight_a, weight_b) = past_weight_percents<FakeCoinA, FakeCoinB>(1);
+        let (weight_a, weight_b) = past_weight_percents<FakeCoinA, FakeCoinB>(2);
+        assert!(weight_a == 0, 0);
+        assert!(weight_b == 0, 0);
+
+        let (weight_a, weight_b) = past_weight_percents<FakeCoinA, FakeCoinB>(4);
+        assert!(weight_a == 0, 0);
+        assert!(weight_b == 0, 0);
+
+        // Epoch [5, 9]
+        let (weight_a, weight_b) = past_weight_percents<FakeCoinA, FakeCoinB>(5);
         assert!(weight_a == 33, 0);
         assert!(weight_b == 67, 0);
 
-        let (weight_a, weight_b) = past_weight_percents<FakeCoinA, FakeCoinB>(2);
+        let (weight_a, weight_b) = past_weight_percents<FakeCoinA, FakeCoinB>(7);
+        assert!(weight_a == 33, 0);
+        assert!(weight_b == 67, 0);
+
+        let (weight_a, weight_b) = past_weight_percents<FakeCoinA, FakeCoinB>(9);
+        assert!(weight_a == 33, 0);
+        assert!(weight_b == 67, 0);
+
+        // Epoch [10, present]
+        let (weight_a, weight_b) = past_weight_percents<FakeCoinA, FakeCoinB>(10);
+        assert!(weight_a == 50, 0);
+        assert!(weight_b == 50, 0);
+
+        let (weight_a, weight_b) = past_weight_percents<FakeCoinA, FakeCoinB>(100);
         assert!(weight_a == 50, 0);
         assert!(weight_b == 50, 0);
     }

--- a/sources/composable_vetoken.move
+++ b/sources/composable_vetoken.move
@@ -1,7 +1,9 @@
 module vetoken::composable_vetoken {
     use std::signer;
+    use std::vector;
 
     use aptos_std::type_info;
+    use aptos_framework::coin::Coin;
 
     use vetoken::dividend_distributor;
     use vetoken::vetoken;
@@ -21,15 +23,24 @@ module vetoken::composable_vetoken {
     const ERR_COMPOSABLE_VETOKEN2_EPOCH_DURATION_MISMATCH: u64 = 101;
     const ERR_COMPOSABLE_VETOKEN2_INVALID_WEIGHTS: u64 = 102;
     const ERR_COMPOSABLE_VETOKEN2_NONMUTABLE_WEIGHTS: u64 = 103;
+    const ERR_COMPOSABLE_VETOKEN2_INVALID_EPOCH: u64 = 104;
 
     ///
     /// Resources
     ///
 
+    struct WeightSnapshot<phantom CoinTypeA, phantom CoinTypeB> has store {
+        weight_percent_coin_a: u128,
+        weight_percent_coin_b: u128,
+        epoch: u64,
+    }
+
     struct ComposedVeToken2<phantom CoinTypeA, phantom CoinTypeB> has key {
         weight_percent_coin_a: u128,
         weight_percent_coin_b: u128,
-        mutable_weights: bool
+        mutable_weights: bool,
+
+        weight_snapshots: vector<WeightSnapshot<CoinTypeA, CoinTypeB>>,
     }
 
     /// Create a ComposedVeToken2 over `CoinTypeA` and `CoinTypeB`. Only `CoinTypeA` is allowed to instantiate
@@ -53,7 +64,9 @@ module vetoken::composable_vetoken {
 
         // the owner of the first coin slot controls configuration for this `ComposedVeToken2`.
         assert!(account_address<CoinTypeA>() == signer::address_of(account), ERR_COMPOSABLE_VETOKEN2_COIN_ADDRESS_MISMATCH);
-        move_to(account, ComposedVeToken2<CoinTypeA, CoinTypeB> { weight_percent_coin_a, weight_percent_coin_b, mutable_weights });
+
+        let weight_snapshots = vector[WeightSnapshot<CoinTypeA, CoinTypeB>{weight_percent_coin_a, weight_percent_coin_b, epoch: vetoken::now_epoch<CoinTypeA>()}];
+        move_to(account, ComposedVeToken2<CoinTypeA, CoinTypeB> { weight_percent_coin_a, weight_percent_coin_b, mutable_weights, weight_snapshots });
     }
 
     public entry fun update_weights<CoinTypeA, CoinTypeB>(account: &signer, weight_percent_coin_a: u128, weight_percent_coin_b: u128) acquires ComposedVeToken2 {
@@ -64,11 +77,30 @@ module vetoken::composable_vetoken {
         let composable_vetoken = borrow_global_mut<ComposedVeToken2<CoinTypeA, CoinTypeB>>(account_address<CoinTypeA>());
         assert!(composable_vetoken.mutable_weights, ERR_COMPOSABLE_VETOKEN2_NONMUTABLE_WEIGHTS);
 
+        let now_epoch = vetoken::now_epoch<CoinTypeA>();
+        let num_snapshots = vector::length(&composable_vetoken.weight_snapshots);
+        let last_snapshot = vector::borrow_mut(&mut composable_vetoken.weight_snapshots, num_snapshots - 1);
+        if (last_snapshot.epoch == now_epoch) {
+            last_snapshot.weight_percent_coin_a = weight_percent_coin_a;
+            last_snapshot.weight_percent_coin_b = weight_percent_coin_b;
+        } else {
+            let weights = WeightSnapshot<CoinTypeA, CoinTypeB>{weight_percent_coin_a, weight_percent_coin_b, epoch: now_epoch};
+            vector::push_back(&mut composable_vetoken.weight_snapshots, weights);
+        };
+
         composable_vetoken.weight_percent_coin_a = weight_percent_coin_a;
         composable_vetoken.weight_percent_coin_b = weight_percent_coin_b;
     }
 
-    #[view] /// Query for the weight configuration
+    /// Lock two tokens for the `ComposedVeToken2` configuration.
+    public fun lock<CoinTypeA, CoinTypeB>(account: &signer, coin_a: Coin<CoinTypeA>, coin_b: Coin<CoinTypeB>, locked_epochs: u64) {
+        assert!(initialized<CoinTypeA, CoinTypeB>(), ERR_COMPOSABLE_VETOKEN2_UNINITIALIZED);
+
+        vetoken::lock(account, coin_a, locked_epochs);
+        vetoken::lock(account, coin_b, locked_epochs);
+    }
+
+    #[view] /// Query for the current weight configuration
     public fun weight_percents<CoinTypeA, CoinTypeB>(): (u128, u128) acquires ComposedVeToken2 {
         let composable_vetoken = borrow_global<ComposedVeToken2<CoinTypeA, CoinTypeB>>(account_address<CoinTypeA>());
         (composable_vetoken.weight_percent_coin_a, composable_vetoken.weight_percent_coin_b)
@@ -97,6 +129,44 @@ module vetoken::composable_vetoken {
         past_weighted_underlying_total_supply<CoinTypeA, CoinTypeB>(vetoken::now_epoch<CoinTypeA>())
     }
 
+    #[view] /// Query for the latest weight configuration at a given epoch
+    public fun past_weight_percents<CoinTypeA, CoinTypeB>(epoch: u64): (u128, u128) acquires ComposedVeToken2 {
+        assert!(initialized<CoinTypeA, CoinTypeB>(), ERR_COMPOSABLE_VETOKEN2_UNINITIALIZED);
+
+        let composable_vetoken = borrow_global<ComposedVeToken2<CoinTypeA, CoinTypeB>>(account_address<CoinTypeA>());
+        let snapshots = &composable_vetoken.weight_snapshots;
+        let num_snapshots = vector::length(snapshots);
+
+        // Check if the latest snapshot suffices
+        let snapshot = vector::borrow(snapshots, num_snapshots - 1);
+        if (epoch == snapshot.epoch) return (snapshot.weight_percent_coin_a, snapshot.weight_percent_coin_b);
+
+        // Check if the first snapshot sufficies or the supplied epoch is too far in the past
+        let snapshot = vector::borrow(snapshots, 0);
+        if (epoch < snapshot.epoch) return (0, 0)
+        else if (epoch == snapshot.epoch) return (snapshot.weight_percent_coin_a, snapshot.weight_percent_coin_b);
+
+        // Binary search a snapshot where the epoch is the highest behind the target epoch. The checks
+        // before this reaching this search ensures that the supplied epoch is in range of [low, hi]
+        //
+        // NOTE: If we reach the terminating condition, low >= hi, then that indicates the the last value
+        // set for `snapshot` (index low - 1) is desired value
+        let low = 0;
+        let high = num_snapshots - 1;
+        while (low < high) {
+            let mid = (low + high) / 2;
+            snapshot = vector::borrow(snapshots, mid);
+
+            // return early if we find an exact epoch
+            if (epoch == snapshot.epoch) return (snapshot.weight_percent_coin_a, snapshot.weight_percent_coin_b);
+
+            if (epoch > snapshot.epoch) low = mid + 1
+            else high = mid
+        };
+
+        return (snapshot.weight_percent_coin_a, snapshot.weight_percent_coin_b)
+    }
+
     #[view] /// Query for the ComposedVeToken2<CoinTypeA, CoinTypeB> balance of this account at a given epoch
     public fun past_balance<CoinTypeA, CoinTypeB>(account_addr: address, epoch: u64): u128 acquires ComposedVeToken2 {
         assert!(initialized<CoinTypeA, CoinTypeB>(), ERR_COMPOSABLE_VETOKEN2_UNINITIALIZED);
@@ -108,7 +178,7 @@ module vetoken::composable_vetoken {
         let balance_b = (vetoken::past_balance<CoinTypeB>(account_addr, epoch) as u128);
 
         // Apply Multipliers
-        let (weight_percent_coin_a, weight_percent_coin_b) = weight_percents<CoinTypeA, CoinTypeB>();
+        let (weight_percent_coin_a, weight_percent_coin_b) = past_weight_percents<CoinTypeA, CoinTypeB>(epoch);
         ((balance_a * weight_percent_coin_a) + (balance_b * weight_percent_coin_b)) / 100
     }
 
@@ -135,8 +205,7 @@ module vetoken::composable_vetoken {
         (total_supply_a * weight_percent_coin_a, total_supply_b * weight_percent_coin_b)
     }
 
-    #[view]
-    /// Return the total amount of `DividendCoin` claimable for two types of underlying VeToken
+    #[view] /// Return the total amount of `DividendCoin` claimable for two types of underlying VeToken
     public fun claimable<CoinTypeA, CoinTypeB, DividendCoin>(account_addr: address): u64 {
         dividend_distributor::claimable<CoinTypeA, DividendCoin>(account_addr) + dividend_distributor::claimable<CoinTypeB, DividendCoin>(account_addr)
     }
@@ -146,8 +215,7 @@ module vetoken::composable_vetoken {
         exists<ComposedVeToken2<CoinTypeA, CoinTypeB>>(account_address<CoinTypeA>())
     }
 
-    #[view]
-    /// For frontend use case: we want to know what the balance will be after increasing lock amount / duration
+    #[view] /// For frontend use case: we want to know what the balance will be after increasing lock amount / duration
     public fun preview_balance_after_increase<CoinTypeA, CoinTypeB>(account_addr: address, amount_a: u64, increment_epochs_a: u64, amount_b: u64, increment_epochs_b: u64): u128 acquires ComposedVeToken2 {
         assert!(initialized<CoinTypeA, CoinTypeB>(), ERR_COMPOSABLE_VETOKEN2_UNINITIALIZED);
 
@@ -252,6 +320,46 @@ module vetoken::composable_vetoken {
         let (weight_a, weight_b) = weight_percents<FakeCoinA, FakeCoinB>();
         assert!(weight_a == 33, 0);
         assert!(weight_b == 67, 0);
+
+    }
+
+    #[test(aptos_framework = @aptos_framework, vetoken = @vetoken)]
+    fun composable_vetoken_past_weight_configuration_ok(aptos_framework: &signer, vetoken: &signer) acquires ComposedVeToken2 {
+        initialize_for_test(aptos_framework, vetoken, 1, 4);
+
+        // Epoch 0 holds no weight configuration
+        timestamp::fast_forward_seconds(vetoken::seconds_in_epoch<FakeCoinA>());
+        initialize<FakeCoinA, FakeCoinB>(vetoken, 100, 50, true);
+
+        // Epoch 1
+        let (weight_a, weight_b) = past_weight_percents<FakeCoinA, FakeCoinB>(0);
+        assert!(weight_a == 0, 0);
+        assert!(weight_b == 0, 0);
+
+        let (weight_a, weight_b) = past_weight_percents<FakeCoinA, FakeCoinB>(1);
+        assert!(weight_a == 100, 0);
+        assert!(weight_b == 50, 0);
+
+        update_weights<FakeCoinA, FakeCoinB>(vetoken, 33, 67);
+        let (weight_a, weight_b) = past_weight_percents<FakeCoinA, FakeCoinB>(1);
+        assert!(weight_a == 33, 0);
+        assert!(weight_b == 67, 0);
+
+        // Epoch 2
+        timestamp::fast_forward_seconds(vetoken::seconds_in_epoch<FakeCoinA>());
+        update_weights<FakeCoinA, FakeCoinB>(vetoken, 50, 50);
+
+        let (weight_a, weight_b) = past_weight_percents<FakeCoinA, FakeCoinB>(0);
+        assert!(weight_a == 0, 0);
+        assert!(weight_b == 0, 0);
+
+        let (weight_a, weight_b) = past_weight_percents<FakeCoinA, FakeCoinB>(1);
+        assert!(weight_a == 33, 0);
+        assert!(weight_b == 67, 0);
+
+        let (weight_a, weight_b) = past_weight_percents<FakeCoinA, FakeCoinB>(2);
+        assert!(weight_a == 50, 0);
+        assert!(weight_b == 50, 0);
     }
 
     #[test(aptos_framework = @aptos_framework, vetoken = @vetoken)]
@@ -307,6 +415,44 @@ module vetoken::composable_vetoken {
         // Only half of FakeCoinB contributes to the total balance
         assert!(balance<FakeCoinA, FakeCoinB>(@0xA) == 375, 0);
         assert!((balance<FakeCoinA, FakeCoinB>(@0xA) as u128) == preview_balance, 0);
+    }
+
+    #[test(aptos_framework = @aptos_framework, vetoken = @vetoken)]
+    fun composable_vetoken_past_balance_ok(aptos_framework: &signer, vetoken: &signer) acquires ComposedVeToken2 {
+        initialize_for_test(aptos_framework, vetoken, 1, 4);
+        initialize<FakeCoinA, FakeCoinB>(vetoken, 100, 50, true);
+
+        // lock the same amounts for both coins
+        let account = &account::create_account_for_test(@0xA);
+        let preview_balance = preview_balance_after_increase<FakeCoinA, FakeCoinB>(@0xA, 1000, 2, 1000, 2);
+        vetoken::lock(account, coin_test::mint_coin<FakeCoinA>(vetoken, 1000), 2);
+        vetoken::lock(account, coin_test::mint_coin<FakeCoinB>(vetoken, 1000), 2);
+        assert!(vetoken::balance<FakeCoinA>(@0xA) == 500, 0);
+        assert!(vetoken::balance<FakeCoinB>(@0xA) == 500, 0);
+
+        // Only half of FakeCoinB contributes to the total balance
+        assert!(balance<FakeCoinA, FakeCoinB>(@0xA) == 750, 0);
+        assert!(preview_balance == 750, 0);
+
+        // Move into Epoch 1. Update weights such that both balances contribute equally
+        timestamp::fast_forward_seconds(vetoken::seconds_in_epoch<FakeCoinA>());
+        update_weights<FakeCoinA, FakeCoinB>(vetoken, 100, 100);
+
+        // Epoch 0 stays the same with old weights
+        assert!(past_balance<FakeCoinA, FakeCoinB>(@0xA, 0) == 750, 0);
+
+        // balances decay in half. Both balances contribute equally. In this Epoch
+        assert!(vetoken::balance<FakeCoinA>(@0xA) == 250, 0);
+        assert!(vetoken::balance<FakeCoinB>(@0xA) == 250, 0);
+        assert!(past_balance<FakeCoinA, FakeCoinB>(@0xA, 1) == 500, 0);
+
+        // Move into Epoch 2. Balances are unlocked
+        timestamp::fast_forward_seconds(vetoken::seconds_in_epoch<FakeCoinA>());
+        update_weights<FakeCoinA, FakeCoinB>(vetoken, 100, 50);
+
+        assert!(past_balance<FakeCoinA, FakeCoinB>(@0xA, 0) == 750, 0);
+        assert!(past_balance<FakeCoinA, FakeCoinB>(@0xA, 1) == 500, 0);
+        assert!(past_balance<FakeCoinA, FakeCoinB>(@0xA, 2) == 0, 0);
     }
 
     #[test(aptos_framework = @aptos_framework, vetoken = @vetoken)]


### PR DESCRIPTION
In order for us to accurately track past balances for composable_vetoken, we need to snapshot weight changes